### PR TITLE
update relative ci agent

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ jobs:
 
       # Send webpack stats and build information to RelativeCI
       - name: Send webpack stats to RelativeCI
-        uses: relative-ci/agent-action@v2.1.7
+        uses: relative-ci/agent-action@v2
         with:
           webpackStatsFile: ./artifacts/webpack-stats.json
           key: ${{ secrets.RELATIVE_CI_KEY }}


### PR DESCRIPTION
- chore: Update agent to latest
- chore: Bump relative-ci/agent to 4.1.7
- chore: Update relative-ci/agent - use latest
